### PR TITLE
Not stored physics processes

### DIFF
--- a/larg4/pluginActions/ParticleListAction_service.cxx
+++ b/larg4/pluginActions/ParticleListAction_service.cxx
@@ -37,6 +37,7 @@
 
 
 #include <algorithm>
+#include <string>
 
 // unused const G4bool debug = false;
 
@@ -83,12 +84,25 @@ namespace larg4 {
     // -- D.R. If a custom list of not storable physics is provided, use it, otherwise
     //    use the default list. This preserves the behavior of the keepEmShowerDaughters
     //    parameter
-    bool customNotStored = (bool)(fNotStoredPhysics.size());
-    if( !customNotStored )
-    { // -- default list of not stored physics
-      fNotStoredPhysics = {"conv","LowEnConversion","Pair","compt","Compt","Brem","phot","Photo","Ion","annihil"};
-    }
+    if (!fKeepEMShowerDaughters)
+    { // -- Don't keep all processes
+      bool customNotStored = (bool)(fNotStoredPhysics.size());
+      if( !customNotStored ) // -- Don't keep but haven't provided a list
+      { // -- default list of not stored physics
+        fNotStoredPhysics = {"conv","LowEnConversion","Pair","compt","Compt","Brem","phot","Photo","Ion","annihil"};
+      }
 
+      std::stringstream sstored;
+      sstored << "The full tracking information will not be stored for particles"
+              << " resulting from the following processes: \n{ ";
+      for (auto i : fNotStoredPhysics) {
+        sstored << "\"" << i << "\" ";
+      }
+      logInfo_ << sstored.str() << "}\n";
+
+    } else { // -- Keep all processes
+      logInfo_ << "Storing full tracking information for all processes. \n";
+    }
   }
 
   art::Event  *ParticleListActionService::getCurrArtEvent() { return (currentArtEvent_); }

--- a/larg4/pluginActions/ParticleListAction_service.cxx
+++ b/larg4/pluginActions/ParticleListAction_service.cxx
@@ -317,7 +317,7 @@ namespace larg4 {
     fCurrentParticle.particle   = new simb::MCParticle( trackID, pdgCode, process_name, parentID, mass);
     fCurrentParticle.truthIndex = primaryIndex;
 
-    fMCTIndexMap[trackID] = primarymctIndex; 
+    fMCTIndexMap[trackID] = primarymctIndex;
     /*
      * mf::LogDebug("MCTIndex") << "(trackID, parentID, MCTIndex) = " << trackID
      *                                   << ", " << parentID << ", " << primarymctIndex;
@@ -527,7 +527,7 @@ namespace larg4 {
 
     //Only change the fTrackIDOffset if there is in fact a particle to add to the event
     if( (fparticleList->size())!=0){
-      fTrackIDOffset = highestID + 1; 
+      fTrackIDOffset = highestID + 1;
       mf::LogDebug("GetList:fTrackIDOffset") << "highestID = " << highestID
                                      << "\nfTrackIDOffset= " << fTrackIDOffset;
     }
@@ -558,7 +558,7 @@ namespace larg4 {
 
     //Only change the fTrackIDOffset if there is in fact a particle to add to the event
     if( (fparticleList->size())!=0 ){
-      fTrackIDOffset = highestID + 1; 
+      fTrackIDOffset = highestID + 1;
       mf::LogDebug("YieldList:fTrackIDOffset") << "highestID = " << highestID
                                      << "\nfTrackIDOffset= " << fTrackIDOffset;
     }

--- a/larg4/pluginActions/ParticleListAction_service.h
+++ b/larg4/pluginActions/ParticleListAction_service.h
@@ -152,6 +152,7 @@ namespace larg4 {
     static int               fTrackIDOffset;         ///< offset added to track ids when running over
                                                      ///< multiple MCTruth objects.
     bool                     fKeepEMShowerDaughters; ///< whether to keep EM shower secondaries, tertiaries, etc
+    std::vector<std::string> fNotStoredPhysics;      ///< Physics processes that will not be stored
 
     std::unique_ptr<thePositionInVolumeFilter> fFilter; ///< filter for particles to be kept
 

--- a/larg4/pluginActions/ParticleListAction_service.h
+++ b/larg4/pluginActions/ParticleListAction_service.h
@@ -162,6 +162,9 @@ namespace larg4 {
     /// Map: particle track ID -> index of primary parent in std::vector<simb::MCTruth> object
     std::map<int, size_t> fMCTIndexMap;
 
+    /// Map: not stored process and counter
+    std::unordered_map<std::string, int> fNotStoredCounterUMap;
+
     // Hold on to the current Art event
     art::Event * currentArtEvent_;
 


### PR DESCRIPTION
Allow for user to set the list of processes to be dropped when keepEMShowerDaughters is set to false. Preserve behavior of keepEMShowerDaughters fhicl parameters for ParticleListAction_service. 