### PR TITLE
Add a fhicl wih the standard configuration of the larg4Main module

### DIFF
--- a/fcl/LArG4.fcl
+++ b/fcl/LArG4.fcl
@@ -1,0 +1,11 @@
+BEGIN_PROLOG
+
+standard_larg4: 
+{
+    module_type: "larg4Main"
+    enableVisualization: false
+    macroPath: ".:./macros"
+    visMacro: "vis.mac"
+}
+
+END_PROLOG

--- a/fcl/testlarg4.fcl
+++ b/fcl/testlarg4.fcl
@@ -1,4 +1,4 @@
-
+#include "LArG4.fcl"
 //#include "seedservice.fcl" 
 #no experiment specific configurations because SingleGen is detector agnostic
 
@@ -105,15 +105,8 @@ out1: {
 
 physics: {
   producers: {
-   generator: @local::standard_singlep
-    larg4Main: {  
-      module_type: larg4Main
-      enableVisualization: false
-      macroPath: ".:./macros" 
-      visMacro: "vis.mac" 
-      //afterEvent: pause
-    }
-
+    generator: @local::standard_singlep
+    larg4Main: @local::standard_larg4
   }
   analyzers: {
    CheckSimEnergyDeposit: {   module_type: CheckSimEnergyDeposit


### PR DESCRIPTION
for use in downstream fhicls, since it appears to be completely generic. Also, update the larg4 example to use it.