### PR TITLE
add linkage to new nug4_additionalG4Physics lib

### DIFF
--- a/larg4/Core/CMakeLists.txt
+++ b/larg4/Core/CMakeLists.txt
@@ -23,6 +23,7 @@ art_make(
     ${G4TRACKING}
     larg4_pluginActions_ParticleListAction_service
     nurandom_RandomUtils_NuRandomService_service
+    nug4_AdditionalG4Physics
     MF_MessageLogger
     ROOT::Core
     ROOT::Physics


### PR DESCRIPTION
requires latest nug4 (pull request 1 on NuSoftHEP/nug4)