### PR TITLE
Ensure initialisation of trackID offset

### DIFF
--- a/larg4/pluginActions/ParticleListAction_service.cxx
+++ b/larg4/pluginActions/ParticleListAction_service.cxx
@@ -138,6 +138,7 @@ namespace larg4 {
     fMCTIndexMap.clear();
     fMCTPrimProcessKeepMap.clear();
     fCurrentTrackID = sim::NoParticleId;
+    fTrackIDOffset = 0;
 
     fPrimaryTruthMap.clear();
     fMCTIndexToGeneratorMap.clear();


### PR DESCRIPTION
LArSoft/larg4#30 introduced functionality to allow for multiple larg4 instances. Since its introduction SBND has noticed an intermittent warning in our g4 tests due to a difference in the number of `MCTracks` produced in `mcreco`.

```
30c30
< G4 | mcreco |  | std::vector<sim::MCTrack> | 383
---
> G4 | mcreco |  | std::vector<sim::MCTrack> | 378
```

We also receive a similarly intermittent failure message in one of our unit tests which also seems to be emanating from the same effect.

```
%MSG
%MSG-s ArtException:  PostEndJob 08-Nov-2021 17:28:36 CST ModuleEndJob
---- EventProcessorFailure BEGIN
  EventProcessor: an exception occurred during current event processing
  ---- ScheduleExecutionFailure BEGIN
    Path: ProcessingStopped.
    ---- LogicError BEGIN
      Failed to match primary particle:
      
      with particles from the truth record 'InputTag: label = 'generator', instance = '', process = 'SingleGen'':
      
      The above exception was thrown while processing module larg4Main/largeant run: 1 subRun: 0 event: 1
    ---- LogicError END
    Exception going through path simulate
  ---- ScheduleExecutionFailure END
---- EventProcessorFailure END
%MSG
```

After some debugging I found that this seems to be related to attempts to access a trackID from the `largeant MCParticle`'s which doesn't exist. From what I can tell this is because the offset parameter in the `ParticleListActionService` is not currently initialised and therefore results in some undefined behaviour, taking different values. 

By adding this line I was able to show offline that this error did not crop up at all in 100 runs of the relevant CI test, compared to a random occurrence of about 1/10 before. I am confident this was the source of the error. 