### PR TITLE
Add a pointer check when looping over processes at post step loop

### DIFF
--- a/larg4/Services/SimEnergyDepositSD.cc
+++ b/larg4/Services/SimEnergyDepositSD.cc
@@ -63,6 +63,7 @@ namespace larg4 {
          G4ProcessVector* procPost = fpSteppingManager->GetfPostStepDoItVector();
          size_t MAXofPostStepLoops = fpSteppingManager->GetMAXofPostStepLoops();
          for (size_t i3 = 0; i3 < MAXofPostStepLoops; i3++) {
+           if (!(*procPost)[i3]) continue;
            /*
              if ((*procPost)[i3]->GetProcessName() == "Cerenkov") {
              G4Cerenkov* proc =(G4Cerenkov*) (*procPost)[i3];


### PR DESCRIPTION
When looping over Post Step Loops, the pointer `(*procPost)[i3]` is checked if NULL if the process is toggled off.
This helps running with config mac file to manually toggle on/off processes.