### PR TITLE
Correct AuxDetHit units

### DIFF
--- a/larg4/Services/AuxDetSD.cc
+++ b/larg4/Services/AuxDetSD.cc
@@ -48,7 +48,7 @@ void  AuxDetSD::Initialize(G4HCofThisEvent* ) {
 }
   //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
   G4bool  AuxDetSD::ProcessHits(G4Step* step, G4TouchableHistory*) {
-  G4double edep = step->GetTotalEnergyDeposit() / CLHEP::MeV;
+  G4double edep = step->GetTotalEnergyDeposit() / CLHEP::GeV;
   if (edep == 0.) return false;
   G4Track * track = step->GetTrack();
   const unsigned int trackID = track->GetTrackID();


### PR DESCRIPTION
I believe this line should read GeV not MeV, in the legacy larg4 this conversion occurred at [this](https://github.com/LArSoft/larsim/blob/develop/larsim/LegacyLArG4/AuxDetReadout.cxx#L56) line. We noticed this issue in SBND's CRT detector simulation where the energy deposits were being interpreted as 1000x their value thus causing the SiPMs to record threshold values for every energy deposit. If there is a reason to leave the conversion until later on then we can add it to the GenericCRT module in larsim but I don't know of one off the top of my head.