### PR TITLE
Feature/hlay update aux hit track ids

### DIFF
--- a/larg4/Services/LArG4Detector.cc
+++ b/larg4/Services/LArG4Detector.cc
@@ -81,6 +81,7 @@ larg4::LArG4DetectorService::LArG4DetectorService(fhicl::ParameterSet const& p)
   , gdmlFileName_{p.get<std::string>("gdmlFileName_", "")}
   , checkOverlaps_{p.get<bool>("CheckOverlaps", false)}
   , updateSimEnergyDeposits_{p.get<bool>("UpdateSimEnergyDeposits", true)}
+  , updateAuxDetHits_{p.get<bool>("UpdateAuxDetHits", true)}
   , volumeNames_{p.get<std::vector<std::string>>("volumeNames", {})}
   , stepLimits_{p.get<std::vector<float>>("stepLimits", {})}
   , inputVolumes_{size(volumeNames_)}
@@ -463,6 +464,14 @@ void larg4::LArG4DetectorService::doFillEventWithArtHits(G4HCofThisEvent* myHC)
     }
     else if (sd_name == "AuxDet") {
       auto auxsd = dynamic_cast<AuxDetSD*>(sd);
+      sim::AuxDetHitCollection hitCollection = auxsd->GetHits();
+      std::map<int, int> tmap = particleListAction->GetTargetIDMap();
+      if (updateAuxDetHits_) {
+        for (auto& hit : hitCollection) {
+	  std::cout << "Changing: " << hit.GetTrackID() << " to " << tmap[hit.GetTrackID()] << std::endl;
+          hit.SetTrackID(tmap[hit.GetTrackID()]);
+        }
+      }
       e.put(make_product(auxsd->GetHits()), instanceName(volume_name));
     }
     else if (sd_name == "Calorimeter") {

--- a/larg4/Services/LArG4Detector.cc
+++ b/larg4/Services/LArG4Detector.cc
@@ -468,7 +468,6 @@ void larg4::LArG4DetectorService::doFillEventWithArtHits(G4HCofThisEvent* myHC)
       std::map<int, int> tmap = particleListAction->GetTargetIDMap();
       if (updateAuxDetHits_) {
         for (auto& hit : hitCollection) {
-	  std::cout << "Changing: " << hit.GetTrackID() << " to " << tmap[hit.GetTrackID()] << std::endl;
           hit.SetTrackID(tmap[hit.GetTrackID()]);
         }
       }

--- a/larg4/Services/LArG4Detector_service.h
+++ b/larg4/Services/LArG4Detector_service.h
@@ -76,6 +76,8 @@ namespace larg4 {
     bool checkOverlaps_;       // enable/disable check of overlaps
     bool
       updateSimEnergyDeposits_; // enable/disable change of TrackID  for Tracks where no MCParticle was created
+    bool
+      updateAuxDetHits_;        // enable/disable change of TrackID  for Tracks where no MCParticle was created
     std::vector<std::string>
       volumeNames_; // list of volume names for which step limits should be set
     std::vector<float>

--- a/larg4/Services/LArG4Detector_service.h
+++ b/larg4/Services/LArG4Detector_service.h
@@ -77,7 +77,7 @@ namespace larg4 {
     bool
       updateSimEnergyDeposits_; // enable/disable change of TrackID  for Tracks where no MCParticle was created
     bool
-      updateAuxDetHits_;        // enable/disable change of TrackID  for Tracks where no MCParticle was created
+      updateAuxDetHits_; // enable/disable change of TrackID  for Tracks where no MCParticle was created
     std::vector<std::string>
       volumeNames_; // list of volume names for which step limits should be set
     std::vector<float>


### PR DESCRIPTION
Currently simulated energy deposits for which we are not saving the relevant MCParticle follow the prescription of being stored with a trackID of:

 -1 * the trackID of their first ancestor which was saved
 
 This is applied in [ParticleListAction](https://github.com/LArSoft/larg4/blob/develop/larg4/pluginActions/ParticleListAction.cc#L328-L362), and the effects of it are applied to `sim::SimEnergyDeposit`s in [LArG4Detector](https://github.com/LArSoft/larg4/blob/develop/larg4/Services/LArG4Detector.cc#L453-L463). 
 
 In SBND we use `sim::SimEnergyDeposit`s for our TPC & PDS systems but `sim::AuxDetHit`s for our CRT. I noticed that the same prescription is not applied to the `sim::AuxDetHit`s to update their track IDs.
 
This PR employs a similar block to do this. I haven't added this to the other objects mentioned in this area of the code but that may be something that people want to consider going forward.