### PR TITLE
Particle Ancestry Map

### DIFF
--- a/larg4/Analysis/CheckMCParticle_module.cc
+++ b/larg4/Analysis/CheckMCParticle_module.cc
@@ -16,6 +16,7 @@
 #include "art_root_io/TFileDirectory.h"
 #include "art_root_io/TFileService.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
+#include "lardataobj/Simulation/ParticleAncestryMap.h"
 
 // Root includes.
 #include "TDirectory.h"
@@ -57,14 +58,14 @@ void larg4::CheckMCParticle::analyze(const art::Event& event)
 {
 #if defined _verbose_
 
-  auto allDropped = event.getMany<std::map<int, std::set<int>>>();
+  auto allDropped = event.getMany<sim::ParticleAncestryMap>();
 
   for (auto const& maps : allDropped) {
-    for (auto const& element : *maps) {
-      std::cout << "Parent of dropped Tracks: " << element.first << std::endl;
-      std::set<int> droppedset = element.second;
-      std::cout << " droppedid size:  " << droppedset.size() << std::endl;
-      for (auto const& droppedid : droppedset) {
+    auto const& map = maps->GetMap();
+    for (auto const& [parent, daughters] : map) {
+      std::cout << "Parent of dropped Tracks: " << parent << std::endl;
+      std::cout << " droppedid size:  " << daughters.size() << std::endl;
+      for (auto const& droppedid : daughters) {
         std::cout << droppedid << " ";
       }
       std::cout << std::endl;

--- a/larg4/Analysis/CheckMCParticle_module.cc
+++ b/larg4/Analysis/CheckMCParticle_module.cc
@@ -15,8 +15,8 @@
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art_root_io/TFileDirectory.h"
 #include "art_root_io/TFileService.h"
-#include "nusimdata/SimulationBase/MCParticle.h"
 #include "lardataobj/Simulation/ParticleAncestryMap.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
 
 // Root includes.
 #include "TDirectory.h"

--- a/larg4/Core/larg4Main_module.cc
+++ b/larg4/Core/larg4Main_module.cc
@@ -37,6 +37,7 @@
 #include "lardataobj/Simulation/GeneratedParticleInfo.h"
 #include "nug4/ParticleNavigation/ParticleList.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
+#include "lardataobj/Simulation/ParticleAncestryMap.h"
 // Geant4 includes
 #include "Geant4/G4UImanager.hh"
 #include "Geant4/G4UIterminal.hh"
@@ -136,7 +137,7 @@ larg4::larg4Main::larg4Main(fhicl::ParameterSet const& p)
   , uiAtBeginRun_(p.get<bool>("uiAtBeginRun", false))
   , afterEvent_(p.get<std::string>("afterEvent", "pass"))
 {
-  produces<std::map<int, std::set<int>>>();
+  produces<sim::ParticleAncestryMap>();
   produces<std::vector<simb::MCParticle>>();
   produces<art::Assns<simb::MCTruth, simb::MCParticle, sim::GeneratedParticleInfo>>();
 

--- a/larg4/Core/larg4Main_module.cc
+++ b/larg4/Core/larg4Main_module.cc
@@ -35,9 +35,9 @@
 // art extensions
 #include "lardataalg/MCDumpers/MCDumpers.h"
 #include "lardataobj/Simulation/GeneratedParticleInfo.h"
+#include "lardataobj/Simulation/ParticleAncestryMap.h"
 #include "nug4/ParticleNavigation/ParticleList.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
-#include "lardataobj/Simulation/ParticleAncestryMap.h"
 // Geant4 includes
 #include "Geant4/G4UImanager.hh"
 #include "Geant4/G4UIterminal.hh"

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -684,7 +684,7 @@ namespace larg4 {
     }
 
     partCol_ = std::make_unique<std::vector<simb::MCParticle>>();
-    droppedCol_ = std::make_unique<std::map<int, std::set<int>>>();
+    droppedCol_ = std::make_unique<sim::ParticleAncestryMap>();
     tpassn_ =
       std::make_unique<art::Assns<simb::MCTruth, simb::MCParticle, sim::GeneratedParticleInfo>>();
     // Set up the utility class for the "for_each" algorithm.  (We only
@@ -725,9 +725,7 @@ namespace larg4 {
           tpassn_->addSingle(mct, mcp_ptr, truthInfo);
         }
         mf::LogDebug("Offset") << "nGeneratedParticles = " << nGeneratedParticles;
-        for (auto const& dropped : fdroppedTracksMap) {
-          droppedCol_->insert(dropped);
-        }
+	droppedCol_->SetMap(fdroppedTracksMap);
         ++nMCTruths;
       }
     }

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -725,7 +725,7 @@ namespace larg4 {
           tpassn_->addSingle(mct, mcp_ptr, truthInfo);
         }
         mf::LogDebug("Offset") << "nGeneratedParticles = " << nGeneratedParticles;
-	droppedCol_->SetMap(fdroppedTracksMap);
+        droppedCol_->SetMap(fdroppedTracksMap);
         ++nMCTruths;
       }
     }

--- a/larg4/pluginActions/ParticleListAction_service.h
+++ b/larg4/pluginActions/ParticleListAction_service.h
@@ -16,6 +16,7 @@
 #include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 
 #include "lardataobj/Simulation/GeneratedParticleInfo.h"
+#include "lardataobj/Simulation/ParticleAncestryMap.h"
 
 #include "artg4tk/actionBase/EventActionBase.hh"
 #include "artg4tk/actionBase/SteppingActionBase.hh"
@@ -99,7 +100,7 @@ namespace larg4 {
     {
       return std::move(partCol_);
     }
-    std::unique_ptr<std::map<int, std::set<int>>> DroppedTracksCollection()
+    std::unique_ptr<sim::ParticleAncestryMap> DroppedTracksCollection()
     {
       return std::move(droppedCol_);
     }
@@ -197,7 +198,7 @@ namespace larg4 {
     std::map<int, std::set<int>> fdroppedTracksMap;
 
     std::unique_ptr<std::vector<simb::MCParticle>> partCol_;
-    std::unique_ptr<std::map<int, std::set<int>>> droppedCol_;
+    std::unique_ptr<sim::ParticleAncestryMap> droppedCol_;
     std::unique_ptr<art::Assns<simb::MCTruth, simb::MCParticle, sim::GeneratedParticleInfo>>
       tpassn_;
     art::ProductID pid_{art::ProductID::invalid()};


### PR DESCRIPTION
Linked to LArSoft/lardataobj#34

Produce the new `sim::ParticleAncestryMap` rather than a raw `std::map<int, std::set<int>>`