### PR TITLE
Feature/cerati particleinvolume

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ cet_set_compiler_flags(DIAGS CAUTIOUS WERROR NO_UNDEFINED EXTRA_FLAGS -pedantic)
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
 
 find_package(larcore REQUIRED EXPORT)
+find_package(larcorealg REQUIRED EXPORT)
 find_package(lardataalg REQUIRED EXPORT)
 find_package(lardataobj REQUIRED EXPORT)
 

--- a/larg4/Core/larg4Main_module.cc
+++ b/larg4/Core/larg4Main_module.cc
@@ -268,6 +268,7 @@ void larg4::larg4Main::produce(art::Event& e)
   art::ServiceHandle<larg4::MCTruthEventActionService>()->setInputCollections(mclists);
 
   art::ServiceHandle<larg4::ParticleListActionService> pla;
+  pla->ParticleFilter();
   pla->setInputCollections(mclists);
   auto const pid = e.getProductID<std::vector<simb::MCParticle>>();
   pla->setPtrInfo(pid, e.productGetter(pid));

--- a/larg4/pluginActions/CMakeLists.txt
+++ b/larg4/pluginActions/CMakeLists.txt
@@ -30,6 +30,8 @@ cet_build_plugin(ParticleListAction artg4tk::ActionService
   messagefacility::MF_MessageLogger
   Geant4::G4global
   ROOT::Core
+  larcorealg::headers
+  larcore::Geometry_Geometry_service
   PRIVATE
   fhiclcpp::fhiclcpp
   ROOT::Physics

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -143,8 +143,6 @@ namespace larg4 {
     fNotStoredCounterUMap.clear();
     fdroppedTracksMap.clear();
     //
-    // need to add this to the map as well, as we may drop particles on the way
-    //fMCTIndexMap[0] = 0;
     // -- D.R. If a custom list of keepGenTrajectories is provided, use it, otherwise
     //    keep or drop decision made based storeTrajectories parameter. This preserves
     //    the behavior of the storeTrajectories fhicl param
@@ -213,7 +211,7 @@ namespace larg4 {
   // trackid
   // assume that the current track id has already been added to
   // the fParentIDMap
-  int ParticleListActionService::GetParentage(int trackid) const//, int fromend
+  int ParticleListActionService::GetParentage(int trackid) const
   {
     int parentid = sim::NoParticleId;
 
@@ -221,6 +219,8 @@ namespace larg4 {
     // of the first EM particle that led to this one
     auto itr = fParentIDMap.find(trackid);
     while (itr != fParentIDMap.end()) {
+      // set the parentid to the current parent ID, when the loop ends
+      // this id will be the first EM particle
       parentid = (*itr).second;
       itr = fParentIDMap.find(parentid);
     }
@@ -345,11 +345,10 @@ namespace larg4 {
           // adding trajectory points to it
           fdroppedTracksMap[this->GetParentage(trackID)].insert(trackID);
           fCurrentParticle.clear();
-	  //
+	  // keep track of this particle in the fMCTIndexMap as well, as we may keep a daughter
 	  if (auto it = fMCTIndexMap.find(parentID); it != cend(fMCTIndexMap)) {
 	    fMCTIndexMap[trackID] = it->second;
 	  }
-	  //
           return;
         } // end if process matches an undesired process
       }   // end if keeping EM shower daughters
@@ -365,11 +364,10 @@ namespace larg4 {
         fParentIDMap[trackID] = parentID;
         fCurrentTrackID = -1 * this->GetParentage(trackID);
         fTargetIDMap[trackID] = fCurrentTrackID;
-	//
+	// keep track of this particle in the fMCTIndexMap as well, as we may keep a daughter
 	if (auto it = fMCTIndexMap.find(parentID); it != cend(fMCTIndexMap)) {
 	  fMCTIndexMap[trackID] = it->second;
 	}
-	//
         return;
       }
 

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -345,10 +345,10 @@ namespace larg4 {
           // adding trajectory points to it
           fdroppedTracksMap[this->GetParentage(trackID)].insert(trackID);
           fCurrentParticle.clear();
-	  // keep track of this particle in the fMCTIndexMap as well, as we may keep a daughter
-	  if (auto it = fMCTIndexMap.find(parentID); it != cend(fMCTIndexMap)) {
-	    fMCTIndexMap[trackID] = it->second;
-	  }
+          // keep track of this particle in the fMCTIndexMap as well, as we may keep a daughter
+          if (auto it = fMCTIndexMap.find(parentID); it != cend(fMCTIndexMap)) {
+            fMCTIndexMap[trackID] = it->second;
+          }
           return;
         } // end if process matches an undesired process
       }   // end if keeping EM shower daughters
@@ -364,10 +364,10 @@ namespace larg4 {
         fParentIDMap[trackID] = parentID;
         fCurrentTrackID = -1 * this->GetParentage(trackID);
         fTargetIDMap[trackID] = fCurrentTrackID;
-	// keep track of this particle in the fMCTIndexMap as well, as we may keep a daughter
-	if (auto it = fMCTIndexMap.find(parentID); it != cend(fMCTIndexMap)) {
-	  fMCTIndexMap[trackID] = it->second;
-	}
+        // keep track of this particle in the fMCTIndexMap as well, as we may keep a daughter
+        if (auto it = fMCTIndexMap.find(parentID); it != cend(fMCTIndexMap)) {
+          fMCTIndexMap[trackID] = it->second;
+        }
         return;
       }
 
@@ -375,7 +375,7 @@ namespace larg4 {
       // if not, then see if it is possible to walk up the fParentIDMap to find the
       // ultimate parent of this particle.  Use that ID as the parent ID for this
       // particle
-      if (!fParticleList.KnownParticle(parentID) && fMCTIndexMap.count(parentID)==0) {
+      if (!fParticleList.KnownParticle(parentID) && fMCTIndexMap.count(parentID) == 0) {
         // do add the particle to the parent id map
         // just in case it makes a daughter that we have to track as well
         fParentIDMap[trackID] = parentID;
@@ -383,7 +383,7 @@ namespace larg4 {
 
         // if we still can't find the parent in the particle navigator,
         // we have to give up
-        if (!fParticleList.KnownParticle(pid) && fMCTIndexMap.count(pid)==0) {
+        if (!fParticleList.KnownParticle(pid) && fMCTIndexMap.count(pid) == 0) {
           MF_LOG_WARNING("ParticleListActionService")
             << "can't find parent id: " << parentID << " in the particle list, or fParentIDMap."
             << " Make " << parentID << " the mother ID for"
@@ -747,7 +747,7 @@ namespace larg4 {
           ++nGeneratedParticles;
           sim::GeneratedParticleInfo const truthInfo{GetPrimaryTruthIndex(p->TrackId())};
           if (!truthInfo.hasGeneratedParticleIndex() && p->Mother() == 0) {
-	     MF_LOG_WARNING("endOfEventAction") << "No GeneratedParticleIndex()!";
+            MF_LOG_WARNING("endOfEventAction") << "No GeneratedParticleIndex()!";
             // this means it's primary but with no information; logic error!!
             throw art::Exception(art::errors::LogicError)
               << "Failed to match primary particle:\n"

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -215,24 +215,16 @@ namespace larg4 {
   // the fParentIDMap
   int ParticleListActionService::GetParentage(int trackid) const//, int fromend
   {
-    //std::vector<int> parentid;
     int parentid = sim::NoParticleId;
 
     // search the fParentIDMap recursively until we have the parent id
     // of the first EM particle that led to this one
     auto itr = fParentIDMap.find(trackid);
     while (itr != fParentIDMap.end()) {
-      // set the parentid to the current parent ID, when the loop ends
-      // this id will be the first EM particle
-      //parentid.push_back( (*itr).second );
-      //itr = fParentIDMap.find(parentid.back());
       parentid = (*itr).second;
       itr = fParentIDMap.find(parentid);
     }
 
-    //std::cout << "GetParentage track id=" << trackid << " return when size=" << parentid.size() << std::endl;
-    //if (parentid.size()>0) return parentid[std::max(size_t(0),parentid.size()-1-fromend)];
-    //return sim::NoParticleId;
     return parentid;
   }
 
@@ -253,8 +245,6 @@ namespace larg4 {
     fTargetIDMap[trackID] = fCurrentTrackID;
     // And the particle's parent (same offset as above):
     int parentID = track->GetParentID() + fTrackIDOffset;
-
-    //std::cout << "preUserTrackingAction track ID=" << trackID << " parent ID=" << parentID << std::endl;
 
     std::string process_name = "unknown";
     std::string mct_primary_process = "unknown";
@@ -323,7 +313,6 @@ namespace larg4 {
       // one of pair production, compton scattering, photoelectric effect
       // bremstrahlung, annihilation, or ionization
       process_name = track->GetCreatorProcess()->GetProcessName();
-      //std::cout << "not primary, fKeepEMShowerDaughters=" << fKeepEMShowerDaughters << std::endl;
       if (!fKeepEMShowerDaughters) {
         bool notstore = false;
         for (auto const& p : fNotStoredPhysics) {
@@ -339,7 +328,6 @@ namespace larg4 {
           }
         }
         if (notstore) {
-	  //std::cout << "dropping trackID=" << trackID << " with parentID=" << parentID << std::endl;
           // figure out the ultimate parentage of this particle
           // first add this track id and its parent to the fParentIDMap
           fParentIDMap[trackID] = parentID;
@@ -370,7 +358,6 @@ namespace larg4 {
       // cut, don't add it to our list.
       G4double energy = track->GetKineticEnergy();
       if (energy < fenergyCut && pdgCode != 0) {
-	//std::cout << "fail e cut" << std::endl;
         fdroppedTracksMap[this->GetParentage(trackID)].insert(trackID);
         fCurrentParticle.clear();
         // do add the particle to the parent id map though
@@ -394,7 +381,7 @@ namespace larg4 {
         // do add the particle to the parent id map
         // just in case it makes a daughter that we have to track as well
         fParentIDMap[trackID] = parentID;
-        int pid = this->GetParentage(parentID);//,1
+        int pid = this->GetParentage(parentID);
 
         // if we still can't find the parent in the particle navigator,
         // we have to give up
@@ -403,8 +390,6 @@ namespace larg4 {
             << "can't find parent id: " << parentID << " in the particle list, or fParentIDMap."
             << " Make " << parentID << " the mother ID for"
             << " track ID " << fCurrentTrackID << " in the hope that it will aid debugging.";
-	  //std::cout << "fMCTIndexMap.count(pid)=" << fMCTIndexMap.count(pid) << " pid=" << pid << std::endl;
-	  //std::cout << "fdroppedTracksMap[parentID]=" << fdroppedTracksMap[parentID].size() << " parentID=" << parentID << std::endl;
         }
         else
           parentID = pid;
@@ -412,8 +397,6 @@ namespace larg4 {
 
       // Once the parentID is secured, inherit the MCTruth Index
       // which should have been set already
-      ////std::cout << __FILE__ << " " << __LINE__ << std::endl;
-      //std::cout << "look for match in fMCTIndexMap for parentID=" << parentID << std::endl;
       if (auto it = fMCTIndexMap.find(parentID); it != cend(fMCTIndexMap)) {
         primarymctIndex = it->second;
       }
@@ -421,7 +404,6 @@ namespace larg4 {
         throw art::Exception(art::errors::LogicError)
           << "Could not locate MCT Index for parent trackID of " << parentID;
       }
-      ////std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
       // Inherit whether the parent is from a primary with MCTruth process_name == "primary"
       isFromMCTProcessPrimary = fMCTPrimProcessKeepMap[parentID];
@@ -436,7 +418,6 @@ namespace larg4 {
       new simb::MCParticle{trackID, pdgCode, process_name, parentID, mass};
     fCurrentParticle.truthIndex = primaryIndex;
 
-    //std::cout << "fill fMCTIndexMap with trackID=" << trackID << " primarymctIndex=" << primarymctIndex << std::endl;
     fMCTIndexMap[trackID] = primarymctIndex;
 
     fMCTPrimProcessKeepMap[trackID] = isFromMCTProcessPrimary;
@@ -463,7 +444,6 @@ namespace larg4 {
     // if we are not filtering, we have a decision already
     if (!fFilter) fCurrentParticle.isInVolume = true;
 
-    //std::cout << "adding particle to list with id=" << fCurrentParticle.particle->TrackId() << " mother=" << fCurrentParticle.particle->Mother() << std::endl;
     fParticleList.Add(fCurrentParticle.particle);
   }
 
@@ -471,8 +451,6 @@ namespace larg4 {
   void ParticleListActionService::postUserTrackingAction(const G4Track* aTrack)
   {
     if (!fCurrentParticle.hasParticle()) return;
-
-    //std::cout << "postUserTrackingAction track ID=" << aTrack->GetTrackID() << " parent ID=" << aTrack->GetParentID() << std::endl;
 
     if (aTrack) {
       fCurrentParticle.particle->SetWeight(aTrack->GetWeight());
@@ -538,14 +516,12 @@ namespace larg4 {
       // do add the particle to the parent id map though
       // and set the current track id to be it's ultimate parent
       fParentIDMap[trackID] = parentID;
-      //std::cout << "erased key=" << key_to_erase << " tid=" << trackID << " pid=" << parentID << " fParentIDMap[trackID]=" << fParentIDMap[trackID] << " fdroppedTracksMap[parentID]=" << fdroppedTracksMap[parentID].size() << " parentage=" << this->GetParentage(trackID) << std::endl;
       fCurrentTrackID = -1 * this->GetParentage(trackID);
       fTargetIDMap[trackID] = fCurrentTrackID;
     }
 
     // store truth record pointer, only if it is available
     if (fCurrentParticle.isPrimary()) {
-      //std::cout << "adding primary with id=" << fCurrentParticle.particle->TrackId() << std::endl;
       fPrimaryTruthMap[fCurrentParticle.particle->TrackId()] = fCurrentParticle.truthInfoIndex();
     }
 
@@ -772,7 +748,6 @@ namespace larg4 {
           assert(p->NumberTrajectoryPoints() != 0ull);
           ++nGeneratedParticles;
           sim::GeneratedParticleInfo const truthInfo{GetPrimaryTruthIndex(p->TrackId())};
-	  std::cout << "truthInfo.hasGeneratedParticleIndex()=" << truthInfo.hasGeneratedParticleIndex() << " p->Mother()=" << p->Mother() << " p->TrackId()=" << p->TrackId() << std::endl;
           if (!truthInfo.hasGeneratedParticleIndex() && p->Mother() == 0) {
 	     MF_LOG_WARNING("endOfEventAction") << "No GeneratedParticleIndex()!";
             // this means it's primary but with no information; logic error!!

--- a/larg4/pluginActions/ParticleListAction_service.h
+++ b/larg4/pluginActions/ParticleListAction_service.h
@@ -119,7 +119,6 @@ namespace larg4 {
     /// Grabs a particle filter
     void ParticleFilter()
     {
-      std::cout << "XXXXXXX ParticleFilter" << std::endl;
       // if we don't have favourite volumes, don't even bother creating a filter
       std::set<std::string> vol_names(fKeepParticlesInVolumes.begin(),
 				      fKeepParticlesInVolumes.end());
@@ -155,7 +154,6 @@ namespace larg4 {
 	pRot->GetAngles(phi, theta, psi);
 	auto pRot2 = new TGeoRotation();
 	pRot2->SetAngles(phi, theta, psi);
-	std::cout << "XXXXXXX volume phi=" << phi << " theta=" << theta << " psi=" << psi << std::endl;
 
 	auto pTransf = new TGeoCombiTrans(*pTransl2, *pRot2);
 	GeoVolumePairs.emplace_back(node_paths[iVolume].back()->GetVolume(), pTransf);
@@ -198,7 +196,7 @@ namespace larg4 {
 
     // this method will loop over the fParentIDMap to get the
     // parentage of the provided trackid
-    int GetParentage(int trackid) const;//, int fromend = 0
+    int GetParentage(int trackid) const;
 
     G4double fenergyCut;             ///< The minimum energy for a particle to
                                      ///< be included in the list.

--- a/larg4/pluginActions/ParticleListAction_service.h
+++ b/larg4/pluginActions/ParticleListAction_service.h
@@ -28,6 +28,9 @@
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include "nusimdata/SimulationBase/simb.h" // simb::GeneratedParticleIndex_t
 
+#include "larcorealg/CoreUtils/ParticleFilters.h"
+#include "larcore/Geometry/Geometry.h"
+
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 
@@ -113,10 +116,59 @@ namespace larg4 {
 
     std::map<int, int> GetTargetIDMap() { return fTargetIDMap; }
 
+    /// Grabs a particle filter
+    void ParticleFilter()
+    {
+      std::cout << "XXXXXXX ParticleFilter" << std::endl;
+      // if we don't have favourite volumes, don't even bother creating a filter
+      std::set<std::string> vol_names(fKeepParticlesInVolumes.begin(),
+				      fKeepParticlesInVolumes.end());
+
+      if (empty(vol_names)) fFilter = {};
+
+      auto const& geom = *art::ServiceHandle<geo::Geometry const>();
+
+      std::vector<std::vector<TGeoNode const*>> node_paths = geom.FindAllVolumePaths(vol_names);
+
+      // collection of interesting volumes
+      util::PositionInVolumeFilter::AllVolumeInfo_t GeoVolumePairs;
+      GeoVolumePairs.reserve(node_paths.size()); // because we are obsessed
+
+      //for each interesting volume, follow the node path and collect
+      //total rotations and translations
+      for (size_t iVolume = 0; iVolume < node_paths.size(); ++iVolume) {
+	std::vector<TGeoNode const*> path = node_paths[iVolume];
+
+	auto pTransl = new TGeoTranslation(0., 0., 0.);
+	auto pRot = new TGeoRotation();
+	for (TGeoNode const* node : path) {
+	  TGeoTranslation thistranslate(*node->GetMatrix());
+	  TGeoRotation thisrotate(*node->GetMatrix());
+	  pTransl->Add(&thistranslate);
+	  *pRot = *pRot * thisrotate;
+	}
+
+	// for some reason, pRot and pTransl don't have tr and rot bits set
+	// correctly make new translations and rotations so bits are set correctly
+	auto pTransl2 = new TGeoTranslation(pTransl->GetTranslation()[0], pTransl->GetTranslation()[1], pTransl->GetTranslation()[2]);
+	double phi = 0., theta = 0., psi = 0.;
+	pRot->GetAngles(phi, theta, psi);
+	auto pRot2 = new TGeoRotation();
+	pRot2->SetAngles(phi, theta, psi);
+	std::cout << "XXXXXXX volume phi=" << phi << " theta=" << theta << " psi=" << psi << std::endl;
+
+	auto pTransf = new TGeoCombiTrans(*pTransl2, *pRot2);
+	GeoVolumePairs.emplace_back(node_paths[iVolume].back()->GetVolume(), pTransf);
+      }
+
+      fFilter = std::make_unique<util::PositionInVolumeFilter>(std::move(GeoVolumePairs));
+    }
+
   private:
     struct ParticleInfo_t {
       simb::MCParticle* particle = nullptr; ///< simple structure representing particle
       bool keepFullTrajectory = false;      ///< if there was decision to keep
+      bool isInVolume = false;              ///< drop if not involume
 
       /// Index of the particle in the original generator truth record.
       simb::GeneratedParticleIndex_t truthIndex = simb::NoGeneratedParticleIndex;
@@ -126,6 +178,7 @@ namespace larg4 {
       {
         particle = nullptr;
         keepFullTrajectory = false;
+        isInVolume = false;
         truthIndex = simb::NoGeneratedParticleIndex;
       }
 
@@ -145,7 +198,7 @@ namespace larg4 {
 
     // this method will loop over the fParentIDMap to get the
     // parentage of the provided trackid
-    int GetParentage(int trackid) const;
+    int GetParentage(int trackid) const;//, int fromend = 0
 
     G4double fenergyCut;             ///< The minimum energy for a particle to
                                      ///< be included in the list.
@@ -175,6 +228,7 @@ namespace larg4 {
     double fSparsifyMargin;        ///< set the sparsification margin
     bool fKeepTransportation;      ///< tell whether or not to keep the transportation process
     bool fKeepSecondToLast; ///< tell whether or not to force keeping the second to last point
+    std::vector<std::string> fKeepParticlesInVolumes;///<Only write particles that have trajectories through these volumes
 
     std::vector<art::Handle<std::vector<simb::MCTruth>>> const*
       fMCLists; ///< MCTruthCollection input lists
@@ -203,6 +257,7 @@ namespace larg4 {
       tpassn_;
     art::ProductID pid_{art::ProductID::invalid()};
     art::EDProductGetter const* productGetter_{nullptr};
+    std::unique_ptr<util::PositionInVolumeFilter> fFilter; ///< filter for particles to be kept
     /// Adds a trajectory point to the current particle, and runs the filter
     void AddPointToCurrentParticle(TLorentzVector const& pos,
                                    TLorentzVector const& mom,

--- a/larg4/pluginActions/ParticleListAction_service.h
+++ b/larg4/pluginActions/ParticleListAction_service.h
@@ -28,8 +28,8 @@
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include "nusimdata/SimulationBase/simb.h" // simb::GeneratedParticleIndex_t
 
-#include "larcorealg/CoreUtils/ParticleFilters.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcorealg/CoreUtils/ParticleFilters.h"
 
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
@@ -121,7 +121,7 @@ namespace larg4 {
     {
       // if we don't have favourite volumes, don't even bother creating a filter
       std::set<std::string> vol_names(fKeepParticlesInVolumes.begin(),
-				      fKeepParticlesInVolumes.end());
+                                      fKeepParticlesInVolumes.end());
 
       if (empty(vol_names)) fFilter = {};
 
@@ -136,27 +136,28 @@ namespace larg4 {
       //for each interesting volume, follow the node path and collect
       //total rotations and translations
       for (size_t iVolume = 0; iVolume < node_paths.size(); ++iVolume) {
-	std::vector<TGeoNode const*> path = node_paths[iVolume];
+        std::vector<TGeoNode const*> path = node_paths[iVolume];
 
-	auto pTransl = new TGeoTranslation(0., 0., 0.);
-	auto pRot = new TGeoRotation();
-	for (TGeoNode const* node : path) {
-	  TGeoTranslation thistranslate(*node->GetMatrix());
-	  TGeoRotation thisrotate(*node->GetMatrix());
-	  pTransl->Add(&thistranslate);
-	  *pRot = *pRot * thisrotate;
-	}
+        auto pTransl = new TGeoTranslation(0., 0., 0.);
+        auto pRot = new TGeoRotation();
+        for (TGeoNode const* node : path) {
+          TGeoTranslation thistranslate(*node->GetMatrix());
+          TGeoRotation thisrotate(*node->GetMatrix());
+          pTransl->Add(&thistranslate);
+          *pRot = *pRot * thisrotate;
+        }
 
-	// for some reason, pRot and pTransl don't have tr and rot bits set
-	// correctly make new translations and rotations so bits are set correctly
-	auto pTransl2 = new TGeoTranslation(pTransl->GetTranslation()[0], pTransl->GetTranslation()[1], pTransl->GetTranslation()[2]);
-	double phi = 0., theta = 0., psi = 0.;
-	pRot->GetAngles(phi, theta, psi);
-	auto pRot2 = new TGeoRotation();
-	pRot2->SetAngles(phi, theta, psi);
+        // for some reason, pRot and pTransl don't have tr and rot bits set
+        // correctly make new translations and rotations so bits are set correctly
+        auto pTransl2 = new TGeoTranslation(
+          pTransl->GetTranslation()[0], pTransl->GetTranslation()[1], pTransl->GetTranslation()[2]);
+        double phi = 0., theta = 0., psi = 0.;
+        pRot->GetAngles(phi, theta, psi);
+        auto pRot2 = new TGeoRotation();
+        pRot2->SetAngles(phi, theta, psi);
 
-	auto pTransf = new TGeoCombiTrans(*pTransl2, *pRot2);
-	GeoVolumePairs.emplace_back(node_paths[iVolume].back()->GetVolume(), pTransf);
+        auto pTransf = new TGeoCombiTrans(*pTransl2, *pRot2);
+        GeoVolumePairs.emplace_back(node_paths[iVolume].back()->GetVolume(), pTransf);
       }
 
       fFilter = std::make_unique<util::PositionInVolumeFilter>(std::move(GeoVolumePairs));
@@ -226,7 +227,8 @@ namespace larg4 {
     double fSparsifyMargin;        ///< set the sparsification margin
     bool fKeepTransportation;      ///< tell whether or not to keep the transportation process
     bool fKeepSecondToLast; ///< tell whether or not to force keeping the second to last point
-    std::vector<std::string> fKeepParticlesInVolumes;///<Only write particles that have trajectories through these volumes
+    std::vector<std::string>
+      fKeepParticlesInVolumes; ///<Only write particles that have trajectories through these volumes
 
     std::vector<art::Handle<std::vector<simb::MCTruth>>> const*
       fMCLists; ///< MCTruthCollection input lists

--- a/test/LArTPCSingleParticle/test_singleparticlelarg4.fcl
+++ b/test/LArTPCSingleParticle/test_singleparticlelarg4.fcl
@@ -132,6 +132,17 @@ ParticleListAction: {service_type: "ParticleListActionService"
                              # of the end of the track (the final step is defined to have 0 kinetic energy)
                              # --- This forces that true penultimate point to be saved, thus preserving the info
 }
+
+Geometry: {
+  SurfaceY:         690                  # in cm, vertical distance to the surface
+  Name:             "LArTPCdetector"
+  GDML:             "LArTPCdetector.gdml"
+  ROOT:             "LArTPCdetector.gdml"
+  DisableWiresInG4:  true
+  SortingParameters: {}
+ }
+ExptGeoInterfaceHelper: { service_provider : StandardGeometryHelper }
+GeometryConfigurationWriter: {}
 }
 
 outputs: {

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -249,9 +249,9 @@ gdmldir	product_dir	gdml
 ####################################
 product		version		qual	flags		<table_format=2>
 artg4tk		v11_00_01	-
-larevt		v09_09_02	-
-nug4		v1_15_01	-
-nurandom	v1_10_01	-
+larevt		v09_09_08	-
+nug4		v1_15_02	-
+nurandom	v1_10_03	-
 cetmodules	v3_20_00	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
This PR adds the feature of optionally restricting the particles that are saved to specified volumes. This feature was present in the "old" G4 but not yet in the refactored version. Tests on ICARUS and SBND show that it gives the expected behavior. 

Note that this was brought up https://cdcvs.fnal.gov/redmine/issues/26106, and having heard no complains, I am moving on with this PR.