### PR TITLE
adjust for G4String::contains deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ cet_cmake_env()
 
 cet_set_compiler_flags(DIAGS CAUTIOUS WERROR NO_UNDEFINED 
                        EXTRA_FLAGS -pedantic
-                                   -Wno-deprecated-declarations
 )
 
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -626,7 +626,7 @@ namespace larg4 {
     // the track passes through, but we don't want to update the
     // trajectory information if the step  was defined by the StepLimiter.
     G4String process = step->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
-    G4bool ignoreProcess = process.contains("StepLimiter");
+    G4bool ignoreProcess = G4StrUtil::contains(process,"StepLimiter");
 
     // We store the initial creation point of the particle
     // and its final position (ie where it has no more energy, or at least < 1 eV) no matter


### PR DESCRIPTION
G4String::contains(str) is replaced by G4StrUtil::contains(g4str,str)
remove -Wno-deprecated-declarations that was otherwise necessary