### PR TITLE
build with geant4 v4_11_2_p02

### DIFF
--- a/larg4/Services/CMakeLists.txt
+++ b/larg4/Services/CMakeLists.txt
@@ -21,7 +21,7 @@ cet_build_plugin(LArG4Detector artg4tk::DetectorService
   Geant4::G4geometry
   Geant4::G4global
   Geant4::G4graphics_reps
-  Geant4::G4persistency
+  Geant4::G4gdml
   Geant4::G4processes
   Geant4::G4run
   Geant4::G4track

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -626,7 +626,7 @@ namespace larg4 {
     // the track passes through, but we don't want to update the
     // trajectory information if the step  was defined by the StepLimiter.
     G4String process = step->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
-    G4bool ignoreProcess = process.contains("StepLimiter");
+    G4bool ignoreProcess = G4StrUtil::contains(process,"StepLimiter");
 
     // We store the initial creation point of the particle
     // and its final position (ie where it has no more energy, or at least < 1 eV) no matter

--- a/larg4/pluginActions/ParticleListAction.cc
+++ b/larg4/pluginActions/ParticleListAction.cc
@@ -626,7 +626,7 @@ namespace larg4 {
     // the track passes through, but we don't want to update the
     // trajectory information if the step  was defined by the StepLimiter.
     G4String process = step->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
-    G4bool ignoreProcess = G4StrUtil::contains(process,"StepLimiter");
+    G4bool ignoreProcess = G4StrUtil::contains(process, "StepLimiter");
 
     // We store the initial creation point of the particle
     // and its final position (ie where it has no more energy, or at least < 1 eV) no matter

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,9 +248,9 @@ gdmldir	product_dir	gdml
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-artg4tk		v12_00_03	-
+artg4tk		v13_00_00	-
 larevt		v10_00_18	-
-nug4		v1_16_11	-
+nug4		v1_17_02	-
 nurandom	v1_11_05	-
 cetmodules	v3_24_01	-	only_for_build
 end_product_list


### PR DESCRIPTION
Changes needed for geant4 4.11.
Replace `Geant4::G4persistency` with `Geant4::G4gdml`.
`process.contains("StepLimiter")` is now `G4StrUtil::contains(process, "StepLimiter")`.
Update dependencies.
Requires https://github.com/LArSoft/larsim/pull/166