### PR TITLE
In LArG4Detector service remove underscores from art product-instance names.

### DIFF
--- a/larg4/Services/LArG4Detector.cc
+++ b/larg4/Services/LArG4Detector.cc
@@ -389,7 +389,13 @@ void larg4::LArG4DetectorService::setStepLimits()
 
 std::string larg4::LArG4DetectorService::instanceName(std::string const& volume_name) const
 {
-  return myName() + volume_name;
+  // Remove underscores from volume name because they are invalid in art instance names.
+
+  std::string result = myName() + volume_name;
+  size_t pos = 0;
+  while((pos = result.find('_', pos)) != std::string::npos)
+    result.erase(pos, 1);
+  return result;
 }
 
 void larg4::LArG4DetectorService::doCallArtProduces(art::ProducesCollector& collector)

--- a/larg4/Services/LArG4Detector.cc
+++ b/larg4/Services/LArG4Detector.cc
@@ -393,7 +393,7 @@ std::string larg4::LArG4DetectorService::instanceName(std::string const& volume_
 
   std::string result = myName() + volume_name;
   size_t pos = 0;
-  while((pos = result.find('_', pos)) != std::string::npos)
+  while ((pos = result.find('_', pos)) != std::string::npos)
     result.erase(pos, 1);
   return result;
 }


### PR DESCRIPTION
LArG4Detector service uses hard-wired art instance names based on volume names in gdml.  If volume names include underscores, this breaks because art instance names aren't allowed to include underscores.

---

_N.B. The `instanceName()` function is used to generate product-instance names for associating data products to geometry._