### PR TITLE
link to nug4 library to enable extra physics list options

### DIFF
--- a/fcl/multigen.fcl
+++ b/fcl/multigen.fcl
@@ -124,9 +124,16 @@ services: {
 
     PhysicsListHolder: {}
     PhysicsList: {
-    PhysicsListName: "FTFP_BERT"
-    DumpList: false
-      enableNeutronLimit: false
+      PhysicsListName: "FTFP_BERT"
+      DumpList: false
+      enableNeutronLimit: false # no special killing of neutrons
+      # NeutronTimeLimit:   10000 # kill after, value in ns ... 10 microsec
+      # NeutronKinELimit:       0 # kill below (MeV)
+      # enableStepLimit: false
+      # enableNuDEX: false
+      # enableBertiniAngularEmissionsAs112: false
+      # enableBertiniNucleiModelAs112:      false
+      # enableOptical: false
       enableCerenkov: false
       enableScintillation: false
       ScintillationByParticleType: false

--- a/larg4/pluginActions/CMakeLists.txt
+++ b/larg4/pluginActions/CMakeLists.txt
@@ -3,6 +3,7 @@ cet_build_plugin(MCTruthEventAction artg4tk::ActionService
   PUBLIC
   nug4::ParticleNavigation
   nug4::G4Base
+  nug4::AdditionalG4Physics
   nusimdata::SimulationBase
   art::Framework_Principal
   art::Framework_Services_Registry


### PR DESCRIPTION
link against nug4::AdditionalG4Physics to allow use of pythia8 tau/charm decay plugins
additionally for artg4tk's PhysicsList fcl paramset show example of new options, document how Neutron killer options cut